### PR TITLE
Atualização do Polygon RPC URL

### DIFF
--- a/missoes/missao-2.md
+++ b/missoes/missao-2.md
@@ -69,7 +69,7 @@ A Metamask vai abrir um formulário para você preencher os dados da rede Polygo
 |                    |                                                                                  |
 | ------------------ | -------------------------------------------------------------------------------- |
 | Network Name       | Mainnet da Polygon                                                               |
-| New RPC URL        | [https://rpc-mainnet.matic.quiknode.pro](https://rpc-mainnet.matic.quiknode.pro) |
+| New RPC URL        | [https://polygon-rpc.com](https://polygon-rpc.com) |
 | Chain ID           | 137                                                                              |
 | Currency Symbol    | MATIC                                                                            |
 | Block Explorer URL | [https://polygonscan.com](https://polygonscan.com)                               |


### PR DESCRIPTION
Ao reproduzir o [passo 1.3 da Missão 2](https://melk.gitbook.io/aprenda-e-ganhe/missoes/missao-2#1.3.-preencha-os-dados-da-rede-polygon), tive problemas ao utilizar o RPC URL sugerido (`https://rpc-mainnet.matic.quiknode.pro`):

![image](https://user-images.githubusercontent.com/16690686/161394295-30add576-c522-41a6-a1fc-65b2afcae9d7.png)

Vi que na documentação da Polygon, no [artigo com instruções para adicionar a Polygon Network](https://docs.polygon.technology/docs/develop/metamask/config-polygon-on-metamask#add-the-polygon-network-manually), estava sendo sugerido a utilização do seguinte endereço: `https://polygon-rpc.com`, que também aponta para a mainnet. Com esse RPC URL funcionou perfeitamente e sem instabilidades.
